### PR TITLE
add tdk info for download page for seo purpose.

### DIFF
--- a/app/download/layout.tsx
+++ b/app/download/layout.tsx
@@ -1,0 +1,11 @@
+// download page tdk info
+export const metadata = {
+    title: 'RustFS 下载安装',
+    description: 'RustFS 是 MinIO 的国产平替, 可在 Linux, docker, macOS, Windows 以及云原生环境下一键式安装部署 RustFS.',
+    keywords: ['Linux', 'Windows', 'docker', 'macOS'],
+  }
+  
+  export default function DownloadLayout({ children }: { children: React.ReactNode }) {
+    return <>{children}</>
+  }
+  


### PR DESCRIPTION
For SEO purposes, different pages should have their own TDK, but now all the pages use the same TDK. Update the download page's TDK (only the download page is the native page for rustfs.com website, the rest page redirects to docs.rustfs.com website). 