### PR TITLE
fix: fix architecture 404 error

### DIFF
--- a/components/business/app-header.tsx
+++ b/components/business/app-header.tsx
@@ -21,7 +21,7 @@ export default function AppHeader() {
     },
     {
       label: t('Architecture'),
-      url: docs_url('architecture.html', locale),
+      url: docs_url('/concepts/architecture.html', locale),
     },
     {
       label: t('Solutions'),


### PR DESCRIPTION
Architecture link has change due to docs refactor. Fix 404 error with correct link.