### PR TITLE
fix: fetch GitHub/Docker metrics client-side instead of build-time

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,8 +7,6 @@ import HomeHero from "@/components/business/home-hero";
 import HomeMultiClouds from "@/components/business/home-multi-clouds";
 import HomeStats from "@/components/business/home-stats";
 import SoftwareLogos from "@/components/business/software-logos";
-import { getDockerPulls } from "@/lib/docker";
-import { getGitHubMetrics } from "@/lib/github";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
@@ -29,16 +27,11 @@ export const metadata: Metadata = {
   },
 };
 
-export default async function HomePage() {
-  const [dockerPulls, metrics] = await Promise.all([
-    getDockerPulls(),
-    getGitHubMetrics(),
-  ]);
-
+export default function HomePage() {
   return (
     <main className="flex-1 relative">
       <div className="relative z-10">
-        <HomeHero dockerPulls={dockerPulls} metrics={metrics} />
+        <HomeHero />
         <SoftwareLogos />
         <HomeFeatures />
         <HomeStats />

--- a/components/business/home-hero.tsx
+++ b/components/business/home-hero.tsx
@@ -2,23 +2,16 @@
 
 import { WordRotate } from "@/components/magicui/word-rotate";
 import { Globe } from "@/components/ui/globe";
-import type { GitHubMetrics } from "@/lib/github";
+import { useMetrics } from "@/hooks/use-metrics";
 import { useTheme } from "next-themes";
 import { useMemo } from "react";
 import ContactUsButton from "./buttons/contact-us";
 import DownloadLink from "./buttons/download-link";
 import StatsStrip from "./stats-strip";
-//import GetStartedButton from "./buttons/get-started";
 
-// 导入所有软件SVG图标
-
-interface HomeHeroProps {
-  dockerPulls: number;
-  metrics: GitHubMetrics;
-}
-
-export default function HomeHero({ dockerPulls, metrics }: HomeHeroProps) {
+export default function HomeHero() {
   const { theme } = useTheme();
+  const { metrics, dockerPulls } = useMetrics();
 
   const isDark = theme === "dark";
 
@@ -74,9 +67,6 @@ export default function HomeHero({ dockerPulls, metrics }: HomeHeroProps) {
           <h1 className="font-display text-3xl font-extrabold tracking-tight text-primary sm:text-4xl md:text-5xl xl:text-6xl leading-tight">
             The fast data foundation for the AI era.
           </h1>
-          {/* <p className="mx-auto lg:mx-0 max-w-2xl text-lg tracking-tight text-secondary-foreground">
-            RustFS is developed with the popular and secure Rust language, compatible with S3 protocol. Suitable for AI/ML and massive data storage, big data, internet, industrial and confidential storage scenarios. Significantly reduces TCO. Follows Apache 2 license, Compatible with diverse hardware ecosystems.
-          </p> */}
           <div className="text-lg font-semibold text-primary/90 flex items-center justify-center lg:justify-start gap-2">
             <span>Built for</span>
             <WordRotate

--- a/hooks/use-metrics.ts
+++ b/hooks/use-metrics.ts
@@ -1,0 +1,86 @@
+'use client';
+
+import type { GitHubMetrics } from '@/lib/github';
+import { useCallback, useEffect, useState } from 'react';
+
+const FALLBACK_METRICS: GitHubMetrics = {
+  stars: 30000,
+  forks: 1300,
+  commits: 2000,
+};
+
+const FALLBACK_DOCKER_PULLS = 6371731;
+
+async function fetchGitHubMetrics(): Promise<GitHubMetrics> {
+  const [repoRes, commitsRes] = await Promise.all([
+    fetch('https://api.github.com/repos/rustfs/rustfs', {
+      headers: { Accept: 'application/vnd.github+json' },
+    }),
+    fetch('https://api.github.com/repos/rustfs/rustfs/commits?per_page=1', {
+      headers: { Accept: 'application/vnd.github+json' },
+    }),
+  ]);
+
+  if (!repoRes.ok || !commitsRes.ok) {
+    return FALLBACK_METRICS;
+  }
+
+  const repo = (await repoRes.json()) as {
+    stargazers_count?: number;
+    forks_count?: number;
+  };
+  const link = commitsRes.headers.get('link');
+  let commits = 0;
+
+  const match = link?.match(/page=(\d+)>; rel="last"/);
+  if (match?.[1]) {
+    commits = Number(match[1]);
+  } else {
+    const data = await commitsRes.json();
+    commits = Array.isArray(data) ? data.length : 0;
+  }
+
+  return {
+    stars: repo.stargazers_count ?? FALLBACK_METRICS.stars,
+    forks: repo.forks_count ?? FALLBACK_METRICS.forks,
+    commits:
+      Number.isFinite(commits) && commits > 0
+        ? commits
+        : FALLBACK_METRICS.commits,
+  };
+}
+
+async function fetchDockerPulls(): Promise<number> {
+  try {
+    const res = await fetch(
+      'https://hub.docker.com/v2/repositories/rustfs/rustfs/',
+    );
+    if (res.ok) {
+      const json = (await res.json()) as { pull_count?: number };
+      return json.pull_count ?? FALLBACK_DOCKER_PULLS;
+    }
+  } catch {
+    // ignore
+  }
+  return FALLBACK_DOCKER_PULLS;
+}
+
+export function useMetrics() {
+  const [metrics, setMetrics] = useState<GitHubMetrics>(FALLBACK_METRICS);
+  const [dockerPulls, setDockerPulls] = useState(FALLBACK_DOCKER_PULLS);
+
+  const load = useCallback(async () => {
+    const [gh, dp] = await Promise.all([
+      fetchGitHubMetrics(),
+      fetchDockerPulls(),
+    ]);
+    setMetrics(gh);
+    setDockerPulls(dp);
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  return { metrics, dockerPulls };
+}


### PR DESCRIPTION
## Problem

Website shows stale metrics (11k stars, 500 forks, 2k commits) while actual GitHub stats are **30k+ stars, 1.3k forks**.

Root cause: the site uses `output: 'export'` (static HTML → Cloudflare Workers), so Next.js ISR (`revalidate: 3600`) doesn't work. Metrics are frozen at build time, and when GitHub API rate-limits the CI build, it falls back to hardcoded values.

## Fix

Move metrics fetching from build-time (server) to client-side (browser):

- **New** `hooks/use-metrics.ts` — fetches GitHub API + Docker Hub on page load, with updated fallback values
- **Updated** `components/business/home-hero.tsx` — uses `useMetrics()` hook instead of server-passed props
- **Updated** `app/page.tsx` — removed server-side async fetching (unnecessary with static export)

Metrics now always reflect live numbers. If the API is unavailable in the browser, fallback to recent values (30k stars, 1.3k forks, 6.3M Docker pulls).
