### PR TITLE
feat: redesign integration page with tabbed docs showcase and SEO

### DIFF
--- a/app/integration/integration-catalog.tsx
+++ b/app/integration/integration-catalog.tsx
@@ -196,7 +196,7 @@ export default function IntegrationCatalog({ categories }: IntegrationCatalogPro
                 </div>
 
                 <div className="mt-auto flex items-center gap-2 pt-6">
-                  <ActionButton href={project.docsUrl} label="Docs" kind="primary" />
+                  <ActionButton href={project.docsUrl} label="Docs" />
                 </div>
               </article>
             );
@@ -217,19 +217,15 @@ function getCategoryPalette(categoryId: string) {
   };
 }
 
-function ActionButton({ href, label, kind }: { href: string; label: string; kind: "primary" | "secondary" }) {
+function ActionButton({ href, label }: { href: string; label: string }) {
   const isExternal = href.startsWith("http://") || href.startsWith("https://");
 
   return (
     <Link
       href={href}
       target={isExternal ? "_blank" : undefined}
-      rel={isExternal ? "noreferrer noopener" : undefined}
-      className={`inline-flex items-center border px-3 py-2 text-[10px] font-semibold uppercase tracking-[0.14em] transition-colors ${
-        kind === "primary"
-          ? "border-brand bg-brand text-brand-foreground hover:bg-brand/90"
-          : "border-border bg-card text-muted-foreground hover:border-brand hover:text-foreground"
-      }`}
+      rel={isExternal ? "noreferrer noopener external" : undefined}
+      className="inline-flex items-center border border-brand bg-brand px-3 py-2 text-[10px] font-semibold uppercase tracking-[0.14em] text-brand-foreground transition-colors hover:bg-brand/90"
     >
       <span>{label}</span>
       <span className="motion-arrow ml-1.5" aria-hidden="true">

--- a/app/integration/integration-catalog.tsx
+++ b/app/integration/integration-catalog.tsx
@@ -1,0 +1,240 @@
+'use client';
+
+import Link from "next/link";
+import { useEffect, useMemo, useState, type KeyboardEvent } from "react";
+
+import { cn } from "@/lib/utils";
+import type { IntegrationCategory, IntegrationProject } from "@/data/integrations";
+
+interface IntegrationCatalogProps {
+  categories: IntegrationCategory[];
+}
+
+interface IntegrationProjectWithCategory extends IntegrationProject {
+  categoryId: string;
+  categoryLabel: string;
+}
+
+export default function IntegrationCatalog({ categories }: IntegrationCatalogProps) {
+  const [activeTab, setActiveTab] = useState("all");
+
+  const tabs = useMemo(
+    () => [
+      { id: "all", label: "ALL" },
+      ...categories.map((category) => ({ id: category.id, label: category.label })),
+    ],
+    [categories],
+  );
+
+  useEffect(() => {
+    const validTabIds = new Set(tabs.map((tab) => tab.id));
+
+    const syncFromHash = () => {
+      const hashValue = window.location.hash.replace(/^#/, "").toLowerCase();
+      if (hashValue && validTabIds.has(hashValue)) {
+        setActiveTab(hashValue);
+        return;
+      }
+      if (!hashValue) {
+        setActiveTab("all");
+      }
+    };
+
+    syncFromHash();
+    window.addEventListener("hashchange", syncFromHash);
+    return () => {
+      window.removeEventListener("hashchange", syncFromHash);
+    };
+  }, [tabs]);
+
+  useEffect(() => {
+    const nextHash = `#${activeTab}`;
+    if (window.location.hash.toLowerCase() === nextHash) {
+      return;
+    }
+    window.history.replaceState(null, "", nextHash);
+  }, [activeTab]);
+
+  const projects = useMemo<IntegrationProjectWithCategory[]>(() => {
+    if (activeTab === "all") {
+      return categories.flatMap((category) =>
+        category.projects.map((project) => ({
+          ...project,
+          categoryId: category.id,
+          categoryLabel: category.label,
+        })),
+      );
+    }
+
+    const category = categories.find((item) => item.id === activeTab);
+    if (!category) {
+      return [];
+    }
+
+    return category.projects.map((project) => ({
+      ...project,
+      categoryId: category.id,
+      categoryLabel: category.label,
+    }));
+  }, [activeTab, categories]);
+
+  const activeTabLabel = tabs.find((tab) => tab.id === activeTab)?.label ?? "ALL";
+
+  const handleTabKeyDown = (event: KeyboardEvent<HTMLButtonElement>, index: number) => {
+    let nextIndex = index;
+
+    if (event.key === "ArrowRight" || event.key === "ArrowDown") {
+      nextIndex = (index + 1) % tabs.length;
+    } else if (event.key === "ArrowLeft" || event.key === "ArrowUp") {
+      nextIndex = (index - 1 + tabs.length) % tabs.length;
+    } else if (event.key === "Home") {
+      nextIndex = 0;
+    } else if (event.key === "End") {
+      nextIndex = tabs.length - 1;
+    } else {
+      return;
+    }
+
+    event.preventDefault();
+    const nextTab = tabs[nextIndex];
+    setActiveTab(nextTab.id);
+    event.currentTarget.parentElement
+      ?.querySelectorAll<HTMLButtonElement>("[role='tab']")
+      [nextIndex]?.focus();
+  };
+
+  return (
+    <div className="mt-8">
+      <nav className="flex gap-px overflow-x-auto border border-border bg-border" role="tablist" aria-label="Integration category tabs">
+        {tabs.map((tab, index) => {
+          const isActive = activeTab === tab.id;
+          const palette = getCategoryPalette(tab.id);
+
+          return (
+            <button
+              key={tab.id}
+              id={`integration-tab-${tab.id}`}
+              type="button"
+              role="tab"
+              aria-selected={isActive}
+              aria-controls="integration-tab-panel"
+              tabIndex={isActive ? 0 : -1}
+              onClick={() => setActiveTab(tab.id)}
+              onKeyDown={(event) => handleTabKeyDown(event, index)}
+              className={cn(
+                "group relative min-h-12 min-w-40 border-0 bg-card px-4 py-3 text-left text-[11px] font-semibold uppercase tracking-[0.16em] text-muted-foreground transition-colors hover:text-foreground focus:outline-hidden focus-visible:ring-2 focus-visible:ring-brand/40",
+                isActive ? cn("text-foreground", palette.tabActive) : "hover:bg-muted/40",
+              )}
+            >
+              <span
+                aria-hidden="true"
+                className={cn(
+                  "absolute inset-y-0 left-0 w-0.5 bg-transparent transition-colors",
+                  isActive && palette.tabStripe,
+                )}
+              />
+              {tab.label}
+            </button>
+          );
+        })}
+      </nav>
+
+      <div
+        id="integration-tab-panel"
+        role="tabpanel"
+        aria-labelledby={`integration-tab-${activeTab}`}
+        className="mt-5 border border-border bg-card p-4 sm:p-5"
+      >
+        <div className="mb-4 flex flex-wrap items-center justify-between gap-3 border-b border-border pb-4">
+          <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">Active tab</p>
+          <div className="flex items-center gap-3">
+            <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-brand">{activeTabLabel}</p>
+            <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">{projects.length} projects</p>
+          </div>
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+          {projects.map((project, index) => {
+            const palette = getCategoryPalette(project.categoryId);
+
+            return (
+              <article
+                key={`${project.categoryLabel}-${project.name}`}
+                data-motion-delay={String(index % 4)}
+                className={cn(
+                  "motion-card motion-reveal group relative flex min-h-56 flex-col overflow-hidden border p-5 transition-colors",
+                  "border-border bg-card hover:border-brand/60 hover:bg-muted/30",
+                )}
+              >
+                <span
+                  aria-hidden="true"
+                  className={cn(
+                    "absolute inset-x-0 top-0 h-0.5",
+                    palette.cardTop,
+                  )}
+                />
+                <span
+                  aria-hidden="true"
+                  className={cn(
+                    "pointer-events-none absolute -right-12 -top-12 h-24 w-24 blur-2xl",
+                    palette.cardAura,
+                  )}
+                />
+
+                <div className="mb-4 flex items-center justify-between gap-4">
+                  <span className={cn("text-[10px] font-semibold uppercase tracking-[0.16em]", palette.caseText)}>
+                    Case.{String(index + 1).padStart(2, "0")}
+                  </span>
+                  <span className="text-[10px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">{project.categoryLabel}</span>
+                </div>
+
+                <div>
+                  <h3 className="text-lg font-semibold leading-tight text-foreground">
+                    {project.name}
+                  </h3>
+                  <p className="mt-3 text-sm leading-6 text-muted-foreground">{project.description}</p>
+                </div>
+
+                <div className="mt-auto flex items-center gap-2 pt-6">
+                  <ActionButton href={project.docsUrl} label="Docs" kind="primary" />
+                </div>
+              </article>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function getCategoryPalette(categoryId: string) {
+  return {
+    tabActive: categoryId === "all" ? "bg-[#0062FF]/12" : "bg-[#0062FF]/10",
+    tabStripe: "bg-[#0062FF]",
+    cardTop: "bg-[#0062FF]",
+    cardAura: "bg-[#0062FF]/25",
+    caseText: "text-[#0062FF]",
+  };
+}
+
+function ActionButton({ href, label, kind }: { href: string; label: string; kind: "primary" | "secondary" }) {
+  const isExternal = href.startsWith("http://") || href.startsWith("https://");
+
+  return (
+    <Link
+      href={href}
+      target={isExternal ? "_blank" : undefined}
+      rel={isExternal ? "noreferrer noopener" : undefined}
+      className={`inline-flex items-center border px-3 py-2 text-[10px] font-semibold uppercase tracking-[0.14em] transition-colors ${
+        kind === "primary"
+          ? "border-brand bg-brand text-brand-foreground hover:bg-brand/90"
+          : "border-border bg-card text-muted-foreground hover:border-brand hover:text-foreground"
+      }`}
+    >
+      <span>{label}</span>
+      <span className="motion-arrow ml-1.5" aria-hidden="true">
+        ↗
+      </span>
+    </Link>
+  );
+}

--- a/app/integration/page.tsx
+++ b/app/integration/page.tsx
@@ -5,8 +5,8 @@ import { integrationCategories } from "@/data/integrations";
 import IntegrationCatalog from "./integration-catalog";
 
 export const metadata: Metadata = {
-  title: "RustFS Integrations | AI, DevOps, Security, Big Data and Proxy Docs",
-  description: "Explore verified RustFS integration guides across AI, DevOps, Backup, Security, Big Data, and Reverse Proxy workflows.",
+  title: "RustFS Integration Directory | AI, DevOps, Security, Big Data, Reverse Proxy",
+  description: "Explore RustFS integration documentation by category, including AI, DevOps, Backup, Security, Big Data, and Reverse Proxy workflows.",
   keywords: [
     "RustFS integrations",
     "RustFS AI integration",
@@ -19,23 +19,51 @@ export const metadata: Metadata = {
   alternates: {
     canonical: `${SITE_CONFIG.primaryDomain}/integration/`,
   },
+  robots: {
+    index: true,
+    follow: true,
+  },
   openGraph: {
-    title: "RustFS Integrations",
-    description: "Integration docs and compatibility references for RustFS ecosystem workflows.",
+    title: "RustFS Integration Directory",
+    description: "Category-based integration documentation for RustFS-compatible workflows.",
     url: `${SITE_CONFIG.primaryDomain}/integration/`,
     siteName: "RustFS",
     type: "website",
   },
   twitter: {
     card: "summary_large_image",
-    title: "RustFS Integrations",
-    description: "Browse RustFS integration docs by category with tab-based navigation.",
+    title: "RustFS Integration Directory",
+    description: "Browse integration documentation by category with hash-shareable tabs.",
   },
 };
 
 export default function IntegrationPage() {
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    name: "RustFS Integration Directory",
+    description: "Category-based integration documentation for RustFS-compatible workflows.",
+    url: `${SITE_CONFIG.primaryDomain}/integration/`,
+    mainEntity: {
+      "@type": "ItemList",
+      itemListElement: integrationCategories.flatMap((category, categoryIndex) =>
+        category.projects.map((project, projectIndex) => ({
+          "@type": "ListItem",
+          position: categoryIndex * 100 + projectIndex + 1,
+          name: `${category.label}: ${project.name}`,
+          url: project.docsUrl,
+        })),
+      ),
+    },
+  };
+
   return (
     <main className="relative flex-1">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+
       <section className="relative overflow-hidden border-y border-border py-16 text-foreground sm:py-24">
         <div
           aria-hidden="true"
@@ -66,6 +94,9 @@ export default function IntegrationPage() {
               All third-party project names are referenced only to describe technical compatibility and integration scenarios.
               Third-party trademarks, names, and brands are the property of their respective owners. RustFS does not imply
               endorsement, partnership, or affiliation unless explicitly stated in separate written agreements.
+            </p>
+            <p className="mt-2 text-sm leading-7 text-muted-foreground">
+              External documentation links may direct to third-party websites managed by their respective owners.
             </p>
           </section>
         </div>

--- a/app/integration/page.tsx
+++ b/app/integration/page.tsx
@@ -1,0 +1,75 @@
+import type { Metadata } from "next";
+
+import { SITE_CONFIG } from "@/app.config";
+import { integrationCategories } from "@/data/integrations";
+import IntegrationCatalog from "./integration-catalog";
+
+export const metadata: Metadata = {
+  title: "RustFS Integrations | AI, DevOps, Security, Big Data and Proxy Docs",
+  description: "Explore verified RustFS integration guides across AI, DevOps, Backup, Security, Big Data, and Reverse Proxy workflows.",
+  keywords: [
+    "RustFS integrations",
+    "RustFS AI integration",
+    "RustFS GitLab integration",
+    "RustFS reverse proxy",
+    "RustFS Keycloak OIDC",
+    "RustFS Iceberg integration",
+    "RustFS Milvus integration",
+  ],
+  alternates: {
+    canonical: `${SITE_CONFIG.primaryDomain}/integration/`,
+  },
+  openGraph: {
+    title: "RustFS Integrations",
+    description: "Integration docs and compatibility references for RustFS ecosystem workflows.",
+    url: `${SITE_CONFIG.primaryDomain}/integration/`,
+    siteName: "RustFS",
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "RustFS Integrations",
+    description: "Browse RustFS integration docs by category with tab-based navigation.",
+  },
+};
+
+export default function IntegrationPage() {
+  return (
+    <main className="relative flex-1">
+      <section className="relative overflow-hidden border-y border-border py-16 text-foreground sm:py-24">
+        <div
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-0 opacity-70 [background-image:linear-gradient(90deg,var(--border)_1px,transparent_1px),linear-gradient(0deg,var(--border)_1px,transparent_1px)] [background-size:34px_34px]"
+        />
+        <div aria-hidden="true" className="pointer-events-none absolute -top-24 -left-20 h-72 w-72 bg-[#0062FF]/16 blur-3xl" />
+        <div aria-hidden="true" className="pointer-events-none absolute -right-16 top-20 h-80 w-80 bg-[#0062FF]/12 blur-3xl" />
+
+        <div className="relative mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+          <div className="mb-8 flex items-center gap-3 text-[11px] font-semibold uppercase tracking-[0.22em] text-muted-foreground">
+            <span className="h-1 w-24 bg-brand" />
+            <span>Integration cases</span>
+          </div>
+
+          <h1 className="max-w-5xl font-display text-5xl font-semibold tracking-tight text-foreground sm:text-7xl">
+            RustFS ecosystem integrations.
+          </h1>
+          <p className="mt-6 max-w-3xl text-sm leading-7 text-muted-foreground">
+            Connect RustFS with DevOps pipelines, AI platforms, cloud-native systems, and analytics engines through
+            standard S3-compatible workflows.
+          </p>
+
+          <IntegrationCatalog categories={integrationCategories} />
+
+          <section className="mt-6 border border-border bg-card/70 p-4 sm:p-5" aria-label="Trademark notice">
+            <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">Trademark notice</p>
+            <p className="mt-2 text-sm leading-7 text-muted-foreground">
+              All third-party project names are referenced only to describe technical compatibility and integration scenarios.
+              Third-party trademarks, names, and brands are the property of their respective owners. RustFS does not imply
+              endorsement, partnership, or affiliation unless explicitly stated in separate written agreements.
+            </p>
+          </section>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/components/business/app-header.tsx
+++ b/components/business/app-header.tsx
@@ -104,7 +104,7 @@ export default function AppHeader() {
   const navs = [
     {
       label: 'Integration',
-      url: '/blog/integration',
+      url: '/integration',
       classes: '',
     },
     {

--- a/data/integrations.ts
+++ b/data/integrations.ts
@@ -1,0 +1,107 @@
+export interface IntegrationProject {
+  name: string;
+  description: string;
+  docsUrl: string;
+}
+
+export interface IntegrationCategory {
+  id: string;
+  label: string;
+  description: string;
+  projects: IntegrationProject[];
+}
+
+export const integrationCategories: IntegrationCategory[] = [
+  {
+    id: "ai",
+    label: "AI",
+    description: "Model training and MLOps stacks that rely on object storage datasets.",
+    projects: [
+      {
+        name: "Milvus",
+        description: "Build vector database workflows on S3-compatible object storage.",
+        docsUrl: "https://docs.rustfs.com/en/developer/integration/big-data/milvus",
+      },
+    ],
+  },
+  {
+    id: "devops",
+    label: "DevOps",
+    description: "CI/CD workflows, platform engineering, and release automation.",
+    projects: [
+      {
+        name: "GitLab",
+        description: "Use OIDC SSO and S3-compatible object storage for pipelines and artifacts.",
+        docsUrl: "https://docs.gitlab.com/administration/object_storage/",
+      },
+    ],
+  },
+  {
+    id: "backup-restore",
+    label: "Backup & Restore",
+    description: "Data protection workflows for snapshots, recovery, and retention.",
+    projects: [
+      {
+        name: "Restic",
+        description: "Store encrypted repository snapshots in S3-compatible backends.",
+        docsUrl: "https://restic.readthedocs.io/en/stable/",
+      },
+    ],
+  },
+  {
+    id: "security",
+    label: "Security",
+    description: "Identity, secrets, and runtime security controls around data access.",
+    projects: [
+      {
+        name: "Keycloak",
+        description: "Use OIDC single sign-on for secure and centralized access control.",
+        docsUrl: "https://docs.rustfs.com/en/security-compliance/oidc/keycloak",
+      },
+      {
+        name: "GitLab",
+        description: "Configure GitLab as OIDC identity provider for enterprise login governance.",
+        docsUrl: "https://docs.rustfs.com/en/security-compliance/oidc/keycloak",
+      },
+    ],
+  },
+  {
+    id: "big-data",
+    label: "Big Data",
+    description: "Analytics and event processing engines with large-scale data movement.",
+    projects: [
+      {
+        name: "Iceberg",
+        description: "Use open table formats with RustFS as the reliable object storage layer.",
+        docsUrl: "https://docs.rustfs.com/en/developer/integration/big-data/iceberg",
+      },
+    ],
+  },
+  {
+    id: "reverse-proxy",
+    label: "Reverse Proxy",
+    description: "Ingress and traffic control layers in front of storage services.",
+    projects: [
+      {
+        name: "Nginx",
+        description: "Expose RustFS endpoints through a battle-tested reverse proxy layer.",
+        docsUrl: "https://docs.rustfs.com/en/developer/integration/reverse-proxy",
+      },
+      {
+        name: "Traefik",
+        description: "Route RustFS traffic dynamically with cloud-native gateway policies.",
+        docsUrl: "https://docs.rustfs.com/en/developer/integration/reverse-proxy",
+      },
+      {
+        name: "Caddy",
+        description: "Publish RustFS services quickly with modern proxy and TLS defaults.",
+        docsUrl: "https://docs.rustfs.com/en/developer/integration/reverse-proxy",
+      },
+      {
+        name: "HAProxy",
+        description: "Balance S3 traffic across nodes for high availability and scale.",
+        docsUrl: "https://docs.rustfs.com/en/developer/integration/reverse-proxy",
+      },
+    ],
+  },
+];


### PR DESCRIPTION
## Summary\n
- add a dedicated /integration page with stronger visual hierarchy and brand-aligned blue accents\n
- implement category tabs with ALL support and URL hash sync for deep links (#ai, #devops, etc.)\n
- introduce structured integration data source and docs-first project cards\n
- update integration navigation entry to point to /integration\n
- refine category/project selection per product requirements (AI/DevOps/Backup/Security/Big Data/Reverse Proxy)\n\n## SEO\n
- add dedicated TDK metadata for /integration\n
- add Open Graph and Twitter metadata\n
- preserve canonical URL and make tab state shareable through hash fragments\n\n

## Notes\n

- no third-party logos were added\n- integration cards now expose only Docs action