### PR TITLE
feat(download): add DEB/RPM packages and Script/DEB/RPM install tabs

### DIFF
--- a/app/download/components/download-page-client.tsx
+++ b/app/download/components/download-page-client.tsx
@@ -191,6 +191,7 @@ type ServerInstallPath = {
   Icon: ComponentType<{ className?: string }>;
   commandTitle: string;
   command: string[];
+  commands?: InstallCommand[];
   chips: string[];
   actions?: {
     href: string;
@@ -198,6 +199,54 @@ type ServerInstallPath = {
     icon: ReactNode;
   }[];
 };
+
+type InstallCommand = {
+  id: string;
+  label: string;
+  title: string;
+  command: string[];
+};
+
+function InstallCommandTabs({
+  commands,
+}: {
+  commands: InstallCommand[];
+}) {
+  const [activeCommandId, setActiveCommandId] = useState(commands[0].id);
+  const activeCommand =
+    commands.find((command) => command.id === activeCommandId) ?? commands[0];
+
+  return (
+    <div>
+      <div className="mb-3 flex border-b border-border" role="tablist" aria-label="Linux install methods">
+        {commands.map((command) => {
+          const isActive = command.id === activeCommand.id;
+
+          return (
+            <button
+              key={command.id}
+              type="button"
+              role="tab"
+              aria-selected={isActive}
+              onClick={() => setActiveCommandId(command.id)}
+              className={cn(
+                "border-b-2 border-b-transparent px-4 py-2 text-sm font-semibold text-muted-foreground transition-colors hover:text-foreground",
+                isActive && "border-b-brand text-brand"
+              )}
+            >
+              {command.label}
+            </button>
+          );
+        })}
+      </div>
+      <CodeBlock
+        title={activeCommand.title}
+        code={activeCommand.command}
+        className="border-brand/60 shadow-[0_0_0_1px_rgba(39,112,246,0.18),0_18px_60px_rgba(39,112,246,0.12)]"
+      />
+    </div>
+  );
+}
 
 function KubernetesInstallCommands() {
   const methods = [
@@ -262,6 +311,18 @@ function ServerInstallTabs({ release }: { release: GitHubRelease | null }) {
   const x86Gnu = findReleaseAsset(release, [/rustfs-linux-x86_64-gnu.*\.zip/i], 'rustfs-linux-x86_64-gnu-latest.zip');
   const armMusl = findReleaseAsset(release, [/rustfs-linux-aarch64-musl.*\.zip/i], 'rustfs-linux-aarch64-musl-latest.zip');
   const armGnu = findReleaseAsset(release, [/rustfs-linux-aarch64-gnu.*\.zip/i], 'rustfs-linux-aarch64-gnu-latest.zip');
+
+  // DEB/RPM native packages from R2
+  const R2_PKG_BASE = 'https://dl.rustfs.com/artifacts/rustfs/packages/release';
+  const tagName = release?.tag_name ?? '';
+  const debVersion = tagName.replace('-', '~'); // 1.0.0-rc.1 -> 1.0.0~rc.1
+  const rpmVersion = tagName.replace('-', '_'); // 1.0.0-rc.1 -> 1.0.0_rc.1
+  const debAmd64Url = tagName ? `${R2_PKG_BASE}/rustfs_${debVersion}_amd64.deb` : '';
+  const debArm64Url = tagName ? `${R2_PKG_BASE}/rustfs_${debVersion}_arm64.deb` : '';
+  const rpmX86Url = tagName ? `${R2_PKG_BASE}/rustfs-${rpmVersion}-1.x86_64.rpm` : '';
+  const rpmArm64Url = tagName ? `${R2_PKG_BASE}/rustfs-${rpmVersion}-1.aarch64.rpm` : '';
+  const debAmd64Filename = debAmd64Url.split('/').pop() ?? '';
+  const rpmX86Filename = rpmX86Url.split('/').pop() ?? '';
   const macArmUrl = release
     ? getDownloadUrlForPlatform(release, 'macos', 'aarch64')
     : null;
@@ -284,12 +345,54 @@ function ServerInstallTabs({ release }: { release: GitHubRelease | null }) {
       command: [
         'curl -O https://rustfs.com/install_rustfs.sh && bash install_rustfs.sh',
       ],
-      chips: ['MUSL / GNU', 'x86_64 / ARM64', 'system service'],
+      commands: [
+        {
+          id: 'script',
+          label: 'Script',
+          title: 'Fast validation',
+          command: [
+            'curl -O https://rustfs.com/install_rustfs.sh && bash install_rustfs.sh',
+          ],
+        },
+        ...(debAmd64Url
+          ? [
+              {
+                id: 'deb',
+                label: 'DEB',
+                title: 'Debian / Ubuntu package',
+                command: [
+                  `curl -O ${debAmd64Url}`,
+                  `sudo dpkg -i ${debAmd64Filename}`,
+                  'rustfs --version',
+                ],
+              },
+            ]
+          : []),
+        ...(rpmX86Url
+          ? [
+              {
+                id: 'rpm',
+                label: 'RPM',
+                title: 'RHEL / Fedora package',
+                command: [
+                  `curl -O ${rpmX86Url}`,
+                  `sudo rpm -ivh ${rpmX86Filename}`,
+                  'rustfs --version',
+                ],
+              },
+            ]
+          : []),
+      ],
+      chips: ['MUSL / GNU', 'DEB / RPM', 'x86_64 / ARM64', 'system service'],
       actions: [
         { href: x86Musl.url, label: 'x86_64 MUSL', icon: <LinuxIcon className="size-4" /> },
         { href: x86Gnu.url, label: 'x86_64 GNU', icon: <LinuxIcon className="size-4" /> },
         { href: armMusl.url, label: 'ARM64 MUSL', icon: <LinuxIcon className="size-4" /> },
         { href: armGnu.url, label: 'ARM64 GNU', icon: <LinuxIcon className="size-4" /> },
+        ...(debAmd64Url ? [{ href: debAmd64Url, label: 'DEB amd64', icon: <LinuxIcon className="size-4" /> }] : []),
+        ...(debArm64Url ? [{ href: debArm64Url, label: 'DEB arm64', icon: <LinuxIcon className="size-4" /> }] : []),
+        ...(rpmX86Url ? [{ href: rpmX86Url, label: 'RPM x86_64', icon: <LinuxIcon className="size-4" /> }] : []),
+        ...(rpmArm64Url ? [{ href: rpmArm64Url, label: 'RPM aarch64', icon: <LinuxIcon className="size-4" /> }] : []),
       ],
     },
     {
@@ -444,7 +547,9 @@ function ServerInstallTabs({ release }: { release: GitHubRelease | null }) {
         </div>
 
         <div className="grid gap-5 p-5 sm:p-6">
-          {activePath.id === 'kubernetes' ? (
+          {activePath.commands ? (
+            <InstallCommandTabs commands={activePath.commands} />
+          ) : activePath.id === 'kubernetes' ? (
             <KubernetesInstallCommands />
           ) : (
             <CodeBlock
@@ -542,7 +647,7 @@ export default function DownloadPageClient() {
               eyebrow="Data service"
               title="RustFS Server"
               description="Server binary, Docker image, and source archive."
-              methods={['Linux', 'Docker', 'Compose', 'Kubernetes', 'macOS', 'Windows']}
+              methods={['Linux', 'DEB / RPM', 'Docker', 'Compose', 'Kubernetes', 'macOS', 'Windows']}
               Icon={ServerIcon}
             />
             <ProductDownloadLink

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -31,9 +31,19 @@ async function fetchGitHub(
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), GITHUB_FETCH_TIMEOUT_MS);
 
+  const headers: Record<string, string> = {
+    ...(init.headers as Record<string, string>),
+  };
+
+  const token = process.env.GITHUB_TOKEN;
+  if (token) {
+    headers['Authorization'] = `Bearer ${token}`;
+  }
+
   try {
     return await fetch(url, {
       ...init,
+      headers,
       signal: controller.signal,
     });
   } finally {


### PR DESCRIPTION
## What

- Add DEB/RPM native package downloads to the Server download page (amd64/arm64 for both formats), with links served from the R2 artifact CDN.
- Split the Linux install command area into **Script / DEB / RPM** tabs, each showing the matching install command:
  - Script: one-click `install_rustfs.sh`
  - DEB: download + `sudo dpkg -i`
  - RPM: download + `sudo rpm -ivh`
- DEB/RPM URLs are derived from the current release tag (e.g. `1.0.0-rc.1` → `1.0.0~rc.1` for DEB, `1.0.0_rc.1` for RPM) and hidden when no release is available.
- Attach an optional `GITHUB_TOKEN` to GitHub API requests to avoid anonymous rate limits.

## Verification

- `pnpm run lint` passed
- `npx tsc --noEmit` passed
- `pnpm run build` passed
