### PR TITLE
fix(ci): pass GITHUB_TOKEN to build to avoid GitHub API rate limits

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,6 +42,8 @@ jobs:
           node-version: 24
 
       - name: Install dependencies and build
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           pnpm install --no-frozen-lockfile
           pnpm run build


### PR DESCRIPTION
## Why

After #91, the production download page is built with the new Script/DEB/RPM tabs, but the DEB/RPM tabs and release info are missing on the live site.

The root cause: the deploy workflow runs `pnpm run build` without a GitHub token, so the build's `getLatestRelease()` call hits the GitHub API anonymously. When the anonymous rate limit is exhausted, the release resolves to `null` and the release-dependent UI (DEB/RPM tabs, release panel, package buttons) is intentionally hidden.

## Fix

Pass the workflow's built-in `github.token` to the build step in `deploy.yml`, so release fetching is authenticated and no longer shares the anonymous 60 requests/hour limit.

## Verification

- With a token present, the build resolves the latest release and the download page renders the Script/DEB/RPM tabs and DEB/RPM packages (verified locally).
- This is a CI-only change; no runtime code is affected.
