### PR TITLE
feat: add deep links to feature items, docs, and blog

### DIFF
--- a/app/product/multiple-protocol-access/page.tsx
+++ b/app/product/multiple-protocol-access/page.tsx
@@ -36,6 +36,7 @@ const sections: FeaturePageSection[] = [
       {
         title: "Drop-in MinIO replacement",
         description: "Zero config overhauls, no API rewrites, and zero migration friction.",
+        href: "/blog/binary-replacement-a-simple-way-to-migrate-from-minio-to-rustfs/",
       },
       {
         title: "Native virtual host mode",

--- a/app/product/operational-observability/page.tsx
+++ b/app/product/operational-observability/page.tsx
@@ -1,5 +1,6 @@
 import FeaturePage, { type FeaturePageSection } from "@/components/business/feature-page";
 import type { Metadata } from "next";
+import Link from "next/link";
 
 export const metadata: Metadata = {
   title: "RustFS Cluster Operations & OTEL Observability | Enterprise Management",
@@ -22,7 +23,19 @@ const sections: FeaturePageSection[] = [
   {
     id: "multi-tenant-management",
     title: "Multi-tenant management",
-    description: "RustFS Operator automates multi-tenant storage operations, from elastic capacity scaling to instant MNMD cluster provisioning with strict resource isolation.",
+    description: (
+      <>
+        <Link
+          href="https://docs.rustfs.com/en/installation/cloud-native/operator"
+          target="_blank"
+          rel="noreferrer"
+          className="text-brand underline decoration-brand/40 underline-offset-4 transition-colors hover:decoration-brand"
+        >
+          RustFS Operator
+        </Link>{" "}
+        automates multi-tenant storage operations, from elastic capacity scaling to instant MNMD cluster provisioning with strict resource isolation.
+      </>
+    ),
     items: [
       {
         title: "Elastic storage auto-scaling",

--- a/components/business/feature-page.tsx
+++ b/components/business/feature-page.tsx
@@ -33,10 +33,11 @@ import type { ReactNode } from "react";
 export interface FeaturePageSection {
   id?: string;
   title: string;
-  description?: string;
+  description?: ReactNode;
   items?: {
     title: string;
     description: string;
+    href?: string;
   }[];
 }
 
@@ -394,7 +395,16 @@ function FeatureSection({
               </span>
               <div>
                 <h3 className="text-lg font-semibold tracking-tight text-foreground">
-                  {item.title}
+                  {item.href ? (
+                    <Link
+                      href={item.href}
+                      className="underline-offset-4 transition-colors hover:text-brand hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand"
+                    >
+                      {item.title}
+                    </Link>
+                  ) : (
+                    item.title
+                  )}
                 </h3>
                 <p className="mt-2 text-sm leading-7 text-muted-foreground">
                   {item.description}

--- a/data/navigation.ts
+++ b/data/navigation.ts
@@ -1,5 +1,3 @@
-import { docs_url } from "@/lib/utils";
-
 export interface NavigationItem {
   title: string;
   href: string;
@@ -67,7 +65,7 @@ export const footerNavigation = [
   {
     title: "Product features",
     links: [
-      { title: "S3 Compatible", href: docs_url("developer/sdk") },
+      { title: "S3 Compatible", href: "/product/multiple-protocol-access#s3-api-compatibility" },
       { title: "Multiple Protocol Access", href: "/product/multiple-protocol-access" },
       { title: "Data Management", href: "/product/data-management" },
       { title: "High Availability & Scale", href: "/product/high-availability-scale" },


### PR DESCRIPTION
## Summary

- Multi-tenant management: link the RustFS Operator mention in the section description to the Operator installation docs (opens in a new tab).
- Footer Product features: S3 Compatible now deep-links to the S3 API compatibility section on the Multiple Protocol Access page.
- Multiple Protocol Access: the Drop-in MinIO replacement feature item links to the MinIO migration blog post.
- FeaturePage now supports rich section descriptions and optional links on feature items.

## Testing

- npx tsc --noEmit passes
- pnpm run lint passes
- pnpm run build passes and sitemap is generated
- Verified the new links render on the dev server