### PR TITLE
fix: point config generator topology link to the server download page

### DIFF
--- a/components/business/rustfs-config-generator.tsx
+++ b/components/business/rustfs-config-generator.tsx
@@ -500,7 +500,7 @@ export default function RustfsConfigGenerator() {
                     Please refer to our{" "}
                     <span className="whitespace-nowrap">
                       <Link
-                        href="/download#topology"
+                        href="/download/server/#topology"
                         className="font-semibold text-brand underline underline-offset-4 transition-colors hover:text-foreground"
                       >
                         installation topology selection


### PR DESCRIPTION
The topology picker (Pick topology after you know the failure domain) is rendered on the server download page. Update the VOLUMES note link in the config generator from /download/#topology to /download/server/#topology.